### PR TITLE
[bug] worker没有结束就退出了

### DIFF
--- a/cmd/brew-bottle-mirror.rb
+++ b/cmd/brew-bottle-mirror.rb
@@ -156,3 +156,4 @@ Formula.core_files.each do |fi|
     end
   end
 end
+pool.join


### PR DESCRIPTION
脚本最后应该`pool.join`，等待所有worker完成任务，否则会有几个文件没下载。