### PR TITLE
Unescape filename when saving on filesystem

### DIFF
--- a/cmd/brew-bottle-mirror.rb
+++ b/cmd/brew-bottle-mirror.rb
@@ -1,5 +1,6 @@
 require "formula"
 require 'thread'
+require 'cgi'  # urldecode (unescape)
 
 class ThreadPool
   class Worker
@@ -132,6 +133,8 @@ Formula.core_files.each do |fi|
       end
       url = "#{root_url}/#{filename}"
 
+      # fix escaped filename on filesystem by CGI::unescape
+      filename = CGI::unescape(filename)
       file = HOMEBREW_CACHE/filename
       tmpfile = HOMEBREW_CACHE/"#{filename}.tmp"
       next if File.exist?(file)


### PR DESCRIPTION
Fixes #7

（我不会写 ruby，所以用法也是现查的。本地测试了一下，可以正确处理类似于 `bison%402.7-2.7.1_1.mojave.bottle.tar.gz` -> `bison@2.7-2.7.1_1.mojave.bottle.tar.gz` 的文件名）