### PR TITLE
Remove checksum.hash_type in script

### DIFF
--- a/cmd/brew-bottle-mirror.rb
+++ b/cmd/brew-bottle-mirror.rb
@@ -116,7 +116,6 @@ Formula.core_files.each do |fi|
         next if os != :x86_64_linux
       end
       checksum = bottle_spec.collector[os]
-      next unless checksum.hash_type == :sha256
       b = Bottle::Filename.create(f, os, bottle_spec.rebuild)
       filename = "#{b.name}-#{b.version}#{b.extname}"
       filename_url_encode = b.bintray


### PR DESCRIPTION
Fixes #9.

虽然还没有搞清楚为什么原先会检查 [`Checksum`](https://rubydoc.brew.sh/Checksum.html) 的 `hash_type`（可能是为了跳过没有 hash 的包？），但是删除这行之后就可以了。本地搭环境测试了一下，下载包也没有问题。
