### PR TITLE
Select checksum string in bottle_spec.collector[os]

### DIFF
--- a/cmd/brew-bottle-mirror.rb
+++ b/cmd/brew-bottle-mirror.rb
@@ -115,7 +115,7 @@ Formula.core_files.each do |fi|
       else
         next if os != :x86_64_linux
       end
-      checksum = bottle_spec.collector[os]
+      checksum = bottle_spec.collector[os][:checksum]
       b = Bottle::Filename.create(f, os, bottle_spec.rebuild)
       filename = "#{b.name}-#{b.version}#{b.extname}"
       filename_url_encode = b.bintray


### PR DESCRIPTION
解决 commit https://github.com/Homebrew/brew/commit/1c027f940ff1710126c476e0dfa942755e3cd61c#diff-bb40db554b6955f972e80737c5883dafef80ffe19b09e0ad1ceeea1cb776f694R427 带来的 hash 校验问题。参考了 https://github.com/Homebrew/brew/commit/1c027f940ff1710126c476e0dfa942755e3cd61c#diff-91b7d3ceb5b783bc460ef7957ed4a960e6d5988c20e925ee78a970e37b8b6954R1834 的修改。

另外的话，顺便问一下……现在 ustcmirrors 还是使用的 threaded 分支，有需要改成 master 吗？